### PR TITLE
Use galactic docker for CI now that it is available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   ros2-sh_CI:
     strategy:
       matrix:
-        node: [foxy, rolling]
+        node: [foxy, galactic]
 
     runs-on: ubuntu-20.04
     container: ros:${{ matrix.node }}


### PR DESCRIPTION
Signed-off-by: Jose Antonio Moral <joseantoniomoralparras@gmail.com>