### PR TITLE
Add test checking internal message filtering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Download the Integration Service
         run: |
-          git clone --recursive -b feature/infinite_loops https://github.com/eProsima/Integration-Service src/integration-service
+          git clone --recursive https://github.com/eProsima/Integration-Service src/integration-service
 
       - name: Build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Download the Integration Service
         run: |
-          git clone --recursive https://github.com/eProsima/Integration-Service src/integration-service
+          git clone --recursive -b feature/infinite_loops https://github.com/eProsima/Integration-Service src/integration-service
 
       - name: Build
         run: |

--- a/ros2/test/CMakeLists.txt
+++ b/ros2/test/CMakeLists.txt
@@ -93,6 +93,7 @@ set_property(
     TARGET ${PROJECT_NAME}_geometry_msgs ${PROJECT_NAME}_test_domain ${PROJECT_NAME}_primitive_msgs ${PROJECT_NAME}_test_qos
     APPEND PROPERTY COMPILE_DEFINITIONS PRIVATE
         "ROS2__GEOMETRY_MSGS__PUBSUB__TEST_CONFIG=\"${CMAKE_CURRENT_LIST_DIR}/resources/ros2__geometry_msgs__pubsub.yaml\""
+        "ROS2__GEOMETRY_MSGS__LOOPBACK__TEST_CONFIG=\"${CMAKE_CURRENT_LIST_DIR}/resources/ros2__geometry_msgs__loopback.yaml\""
         "ROS2__GEOMETRY_MSGS__SERVICES__TEST_CONFIG=\"${CMAKE_CURRENT_LIST_DIR}/resources/ros2__geometry_msgs__services.yaml\""
         "ROS2__TEST_DOMAIN__TEST_CONFIG=\"${CMAKE_CURRENT_LIST_DIR}/resources/ros2__domain_change.yaml\""
         "ROS2__ROSIDL__BUILD_DIR=\"${CMAKE_BINARY_DIR}/is/rosidl/ros2/lib\""

--- a/ros2/test/resources/ros2__geometry_msgs__loopback.yaml
+++ b/ros2/test/resources/ros2__geometry_msgs__loopback.yaml
@@ -1,0 +1,18 @@
+systems:
+  ros2: { type: ros2 }
+  mock: { type: mock, types-from: ros2 }
+
+routes:
+  mock_to_ros2: { from: mock, to: ros2 }
+  ros2_to_mock: { from: ros2, to: mock }
+
+topics:
+  transmit_pose:
+    type: "geometry_msgs/Pose"
+    route: mock_to_ros2
+    remap: { ros2: { topic: "mock_to_ros2_to_mock" } }
+
+  echo_pose:
+    type: "geometry_msgs/Pose"
+    route: ros2_to_mock
+    remap: { ros2: { topic: "mock_to_ros2_to_mock" } }


### PR DESCRIPTION
This should fail for *Foxy* docker (using default RMW: FastDDS) until https://github.com/ros2/rmw_fastrtps/pull/535 (or backport from https://github.com/ros2/rmw_fastrtps/pull/536) is merged.

Update 11/08/2021: The backports are closed without merging, so the new test still fail. Rerun the jobs when the fix is merged into *Foxy* and *Galactic*.

Signed-off-by: Jose Antonio Moral <joseantoniomoralparras@gmail.com>