### PR TITLE
fix: PYTHON_EXECUTABLE was not being set, so use find_package to do it

### DIFF
--- a/utils/ros2-mix-generator/cmake/is_ros2_rosidl_mix.cmake
+++ b/utils/ros2-mix-generator/cmake/is_ros2_rosidl_mix.cmake
@@ -66,12 +66,16 @@ function(is_ros2_rosidl_mix)
         endif()
     endforeach()
 
+    if(NOT Python_EXECUTABLE)
+        find_package(Python COMPONENTS Interpreter)
+    endif()
+
     is_mix_generator(
         IDL_TYPE
             rosidl
         SCRIPT
             INTERPRETER
-                ${PYTHON_EXECUTABLE}
+                ${Python_EXECUTABLE}
             FIND
                 ${CMAKE_CURRENT_LIST_DIR}/scripts/is_ros2_rosidl_find_package_info.py
             GENERATE


### PR DESCRIPTION
I was running into issues building this on Ubuntu Jammy with ROS2 Humble and tracked down the issue to this.

Fixes https://github.com/eProsima/Integration-Service/issues/178