### PR TITLE
fix: use ROS2 interfaces instead of ROS1

### DIFF
--- a/ros2/test/integration/ros2__test_qos.cpp
+++ b/ros2/test/integration/ros2__test_qos.cpp
@@ -124,7 +124,7 @@ public:
             ASSERT_EQ(msg_future.wait_for(0s), std::future_status::ready);
             xtypes::DynamicData received_msg = msg_future.get();
 
-            EXPECT_EQ(received_msg.type().name(), "std_msgs/String");
+            EXPECT_EQ(received_msg.type().name(), "std_msgs/msg/String");
 
             xtypes::ReadableDynamicDataRef xtypes_msg = received_msg;
             typename std_msgs::msg::String::_data_type ros2_field;
@@ -165,7 +165,7 @@ TEST_F(ROS2QoS, Durability_Incompatible_QoS)
     yaml += "   mock_to_ros2: { from: mock, to: ros2 }\n";
     yaml += "   ros2_to_mock: { from: ros2, to: mock }\n";
     yaml += "topics:\n";
-    yaml += "   transmit: { type: 'std_msgs/String', route: ros2_to_mock, ";
+    yaml += "   transmit: { type: 'std_msgs/msg/String', route: ros2_to_mock, ";
     yaml += "   ros2: { qos: { durability: TRANSIENT_LOCAL } } }\n";
 
     set_up(yaml);
@@ -188,7 +188,7 @@ TEST_F(ROS2QoS, Durability_Compatible_QoS)
     yaml += "   mock_to_ros2: { from: mock, to: ros2 }\n";
     yaml += "   ros2_to_mock: { from: ros2, to: mock }\n";
     yaml += "topics:\n";
-    yaml += "   transmit: { type: 'std_msgs/String', route: ros2_to_mock, ";
+    yaml += "   transmit: { type: 'std_msgs/msg/String', route: ros2_to_mock, ";
     yaml += "   ros2: { qos: { durability: VOLATILE } } }\n";
 
     set_up(yaml);
@@ -211,7 +211,7 @@ TEST_F(ROS2QoS, Deadline_Incompatible_QoS)
     yaml += "   mock_to_ros2: { from: mock, to: ros2 }\n";
     yaml += "   ros2_to_mock: { from: ros2, to: mock }\n";
     yaml += "topics:\n";
-    yaml += "   transmit: { type: 'std_msgs/String', route: ros2_to_mock, ";
+    yaml += "   transmit: { type: 'std_msgs/msg/String', route: ros2_to_mock, ";
     yaml += "   ros2: { qos: { deadline: { sec: 1 } } } }\n";
 
     set_up(yaml);
@@ -234,7 +234,7 @@ TEST_F(ROS2QoS, Deadline_Compatible_QoS)
     yaml += "   mock_to_ros2: { from: mock, to: ros2 }\n";
     yaml += "   ros2_to_mock: { from: ros2, to: mock }\n";
     yaml += "topics:\n";
-    yaml += "   transmit: { type: 'std_msgs/String', route: ros2_to_mock, ";
+    yaml += "   transmit: { type: 'std_msgs/msg/String', route: ros2_to_mock, ";
     yaml += "   ros2: { qos: { deadline: { sec: 2 } } } }\n";
 
     set_up(yaml);
@@ -257,7 +257,7 @@ TEST_F(ROS2QoS, Liveliness_Incompatible_QoS)
     yaml += "   mock_to_ros2: { from: mock, to: ros2 }\n";
     yaml += "   ros2_to_mock: { from: ros2, to: mock }\n";
     yaml += "topics:\n";
-    yaml += "   transmit: { type: 'std_msgs/String', route: ros2_to_mock, ";
+    yaml += "   transmit: { type: 'std_msgs/msg/String', route: ros2_to_mock, ";
     yaml += "   ros2: { qos: { liveliness: { kind: MANUAL_BY_TOPIC } } } }\n";
 
     set_up(yaml);
@@ -280,7 +280,7 @@ TEST_F(ROS2QoS, Liveliness_Compatible_QoS)
     yaml += "   mock_to_ros2: { from: mock, to: ros2 }\n";
     yaml += "   ros2_to_mock: { from: ros2, to: mock }\n";
     yaml += "topics:\n";
-    yaml += "   transmit: { type: 'std_msgs/String', route: ros2_to_mock, ";
+    yaml += "   transmit: { type: 'std_msgs/msg/String', route: ros2_to_mock, ";
     yaml += "   ros2: { qos: { liveliness: { kind: AUTOMATIC } } } }\n";
 
     set_up(yaml);
@@ -303,7 +303,7 @@ TEST_F(ROS2QoS, Lease_Duration_Incompatible_QoS)
     yaml += "   mock_to_ros2: { from: mock, to: ros2 }\n";
     yaml += "   ros2_to_mock: { from: ros2, to: mock }\n";
     yaml += "topics:\n";
-    yaml += "   transmit: { type: 'std_msgs/String', route: ros2_to_mock, ";
+    yaml += "   transmit: { type: 'std_msgs/msg/String', route: ros2_to_mock, ";
     yaml += "   ros2: { qos: { liveliness: { sec: 1 } } } }\n";
 
     set_up(yaml);
@@ -325,7 +325,7 @@ TEST_F(ROS2QoS, Lease_Duration_Compatible_QoS)
     yaml += "   mock_to_ros2: { from: mock, to: ros2 }\n";
     yaml += "   ros2_to_mock: { from: ros2, to: mock }\n";
     yaml += "topics:\n";
-    yaml += "   transmit: { type: 'std_msgs/String', route: ros2_to_mock, ";
+    yaml += "   transmit: { type: 'std_msgs/msg/String', route: ros2_to_mock, ";
     yaml += "   ros2: { qos: { liveliness: { sec: 3 } } } }\n";
 
     set_up(yaml);
@@ -348,7 +348,7 @@ TEST_F(ROS2QoS, Reliability_Incompatible_QoS)
     yaml += "   mock_to_ros2: { from: mock, to: ros2 }\n";
     yaml += "   ros2_to_mock: { from: ros2, to: mock }\n";
     yaml += "topics:\n";
-    yaml += "   transmit: { type: 'std_msgs/String', route: ros2_to_mock, ";
+    yaml += "   transmit: { type: 'std_msgs/msg/String', route: ros2_to_mock, ";
     yaml += "   ros2: { qos: { reliability: RELIABLE } } }\n";
 
     set_up(yaml);
@@ -371,7 +371,7 @@ TEST_F(ROS2QoS, Reliability_Compatible_QoS)
     yaml += "   mock_to_ros2: { from: mock, to: ros2 }\n";
     yaml += "   ros2_to_mock: { from: ros2, to: mock }\n";
     yaml += "topics:\n";
-    yaml += "   transmit: { type: 'std_msgs/String', route: ros2_to_mock, ";
+    yaml += "   transmit: { type: 'std_msgs/msg/String', route: ros2_to_mock, ";
     yaml += "   ros2: { qos: { reliability: BEST_EFFORT } } }\n";
 
     set_up(yaml);

--- a/ros2/test/resources/ros2__domain_change.yaml
+++ b/ros2/test/resources/ros2__domain_change.yaml
@@ -6,4 +6,4 @@ routes:
     domain_5_to_10: { from: ros2_domain5, to: ros2_domain10 }
 
 topics:
-    string_topic: { type: "std_msgs/String", route: domain_5_to_10 }
+    string_topic: { type: "std_msgs/msg/String", route: domain_5_to_10 }

--- a/ros2/test/resources/ros2__geometry_msgs__pubsub.yaml
+++ b/ros2/test/resources/ros2__geometry_msgs__pubsub.yaml
@@ -7,5 +7,5 @@ routes:
   ros2_to_mock: { from: ros2, to: mock }
 
 topics:
-  transmit_pose: { type: "geometry_msgs/Pose", route: ros2_to_mock }
-  echo_pose: { type: "geometry_msgs/Pose", route: mock_to_ros2 }
+  transmit_pose: { type: "geometry_msgs/msg/Pose", route: ros2_to_mock }
+  echo_pose: { type: "geometry_msgs/msg/Pose", route: mock_to_ros2 }

--- a/ros2/test/resources/ros2__geometry_msgs__services.yaml
+++ b/ros2/test/resources/ros2__geometry_msgs__services.yaml
@@ -7,5 +7,5 @@ routes:
   ros2_srv: { server: ros2, clients: mock }
 
 services:
-  get_plan: { type: "nav_msgs/GetPlan:request", route: ros2_srv }
-  echo_plan: { type: "nav_msgs/GetPlan:response", route: mock_srv }
+  get_plan: { type: "nav_msgs/srv/GetPlan:request", route: ros2_srv }
+  echo_plan: { type: "nav_msgs/srv/GetPlan:response", route: mock_srv }

--- a/ros2/test/resources/ros2__websocket__test.yaml
+++ b/ros2/test/resources/ros2__websocket__test.yaml
@@ -14,4 +14,4 @@ routes:
   ros2_to_websocket: { from: ros2, to: websocket }
 
 topics:
-  helloworld: { type: "std_msgs/String", route: websocket_to_ros2, remap: {websocket: {type: std_msgs__String}} }
+  helloworld: { type: "std_msgs/msg/String", route: websocket_to_ros2, remap: {websocket: {type: std_msgs__String}} }

--- a/utils/ros2-mix-generator/resources/convert__msg.hpp.em
+++ b/utils/ros2-mix-generator/resources/convert__msg.hpp.em
@@ -20,7 +20,7 @@ underscore_msg_type = get_header_filename_from_msg_name(camelcase_msg_type)
 cpp_msg_type = '{}::msg::{}'.format(
       spec.base_type.pkg_name, camelcase_msg_type)
 
-msg_type_string = '{}/{}'.format(
+msg_type_string = '{}/msg/{}'.format(
       spec.base_type.pkg_name, camelcase_msg_type)
 
 header_guard_parts = [

--- a/utils/ros2-mix-generator/resources/convert__srv.cpp.em
+++ b/utils/ros2-mix-generator/resources/convert__srv.cpp.em
@@ -16,7 +16,7 @@ underscore_srv_type = get_header_filename_from_msg_name(camelcase_srv_type)
 
 cpp_srv_type = '{}::srv::{}'.format(spec.pkg_name, camelcase_srv_type)
 
-srv_type_string = '{}/{}'.format(spec.pkg_name, camelcase_srv_type)
+srv_type_string = '{}/srv/{}'.format(spec.pkg_name, camelcase_srv_type)
 
 namespace_parts_srv = [
     'convert', spec.pkg_name, 'srv', underscore_srv_type]


### PR DESCRIPTION
There was a conflict between ROS1 and ROS2 interface naming. This fixes it and ROS2 interfaces must be specified with this format: `std_msgs/msg/String`

Fixes https://github.com/eProsima/Integration-Service/issues/180

