### PR TITLE
Refs 18334. Fixing tests CMakeLists.txt for humble

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,10 +265,6 @@ whole *Integration Service* product suite, there are some specific flags which a
   ~/is_ws$ colcon build --cmake-args -DBUILD_ROS2_TESTS=ON
   ```
 
-* `IS_ROS2_DISTRO`: This flag is intended to select the *ROS 2* distro that should be used to compile the *ROS 2 System Handle*.
-  If not set, the version will be retrieved from the last *ROS distro* sourced in the compilation environment;
-  this means that if the last *ROS* environment sourced corresponds to *ROS 1*, the compilation process will stop and warn the user about it.
-
 * `MIX_ROS_PACKAGES`: It accepts as an argument a list of [ROS packages](https://index.ros.org/packages/),
   such as `std_msgs`, `geometry_msgs`, `sensor_msgs`, `nav_msgs`... for which the required transformation
   library to convert the specific ROS 2 type definitions into *xTypes*, and the other way around, will be built.

--- a/ros2/CMakeLists.txt
+++ b/ros2/CMakeLists.txt
@@ -44,26 +44,6 @@ endif()
 # External dependencies for the Integration Service ROS 2 SystemHandle library
 ###################################################################################
 if(BUILD_LIBRARY)
-    # Check if the user specified which ROS 2 version he/she is using. If not, warn and try to automatically get it
-    if(NOT IS_ROS2_DISTRO)
-
-        message(WARNING "
-            The variable 'IS_ROS2_DISTRO' was not used. You might want to set it to
-            specify which ROS 2 version should be used to compile the ROS 2 System Handle.
-            By default, a ROS 2 version from the sourced environment will be retrieved automatically.")
-
-            if ("$ENV{ROS_VERSION}" STREQUAL "1")
-                message(FATAL_ERROR "
-                    A ROS 1 version was sourced last in your build environment.
-                    Please use the 'IS_ROS2_VERSION' variable!")
-            else()
-                set(IS_ROS2_DISTRO $ENV{ROS_DISTRO})
-            endif()
-
-    endif()
-
-    message(STATUS "Compiling the ${PROJECT_NAME} System Handle for ROS 2 ${IS_ROS2_DISTRO}...")
-
     find_package(is-core REQUIRED)
     find_package(rclcpp REQUIRED)
 endif()
@@ -75,8 +55,8 @@ if(BUILD_LIBRARY)
     add_library(${PROJECT_NAME}
         SHARED
             src/Factory.cpp
-            $<IF:$<STREQUAL:"${IS_ROS2_DISTRO}","foxy">,src/SystemHandle__foxy.cpp,src/SystemHandle.cpp>
             src/MetaPublisher.cpp
+            $<IF:$<VERSION_GREATER:${rclcpp_VERSION},2.4.2>,src/SystemHandle.cpp,src/SystemHandle__foxy.cpp>
         )
 
     if (Sanitizers_FOUND)

--- a/ros2/test/CMakeLists.txt
+++ b/ros2/test/CMakeLists.txt
@@ -54,6 +54,7 @@ macro(compile_test)
 
     target_include_directories(${TEST_NAME}
         PRIVATE
+            ${rclcpp_INCLUDE_DIRS}
             ${geometry_msgs_INCLUDE_DIRS}
             ${nav_msgs_INCLUDE_DIRS}
             ${std_msgs_INCLUDE_DIRS}

--- a/ros2/test/CMakeLists.txt
+++ b/ros2/test/CMakeLists.txt
@@ -82,10 +82,10 @@ compile_test(${PROJECT_NAME}_geometry_msgs SOURCE integration/ros2__geometry_msg
 compile_test(${PROJECT_NAME}_primitive_msgs SOURCE integration/ros2__primitives_msgs.cpp)
 compile_test(${PROJECT_NAME}_test_qos SOURCE integration/ros2__test_qos.cpp)
 
-if ("${IS_ROS2_DISTRO}" STREQUAL "foxy")
-    compile_test(${PROJECT_NAME}_test_domain SOURCE integration/ros2__test_domain__foxy.cpp)
-else()
+if (rclcpp_VERSION VERSION_GREATER 2.4.2)
     compile_test(${PROJECT_NAME}_test_domain SOURCE integration/ros2__test_domain.cpp)
+else()
+    compile_test(${PROJECT_NAME}_test_domain SOURCE integration/ros2__test_domain__foxy.cpp)
 endif()
 
 set(test_msgs_config_file "ros2__test_msgs.yaml")


### PR DESCRIPTION
- includes some missing search paths
- upgrades the source selection system using cmake versioning capabilities instead of trying to infer the ros2 version