### PR TITLE
Refs 19049. Fixing rclcpp cmake version check

### DIFF
--- a/ros2/dynamic/test/CMakeLists.txt
+++ b/ros2/dynamic/test/CMakeLists.txt
@@ -108,7 +108,7 @@ enable_testing()
 compile_test(${PROJECT_NAME}_geometry_msgs SOURCE integration/ros2__geometry_msgs.cpp)
 compile_test(${PROJECT_NAME}_test_qos SOURCE integration/ros2__test_qos.cpp)
 
-if (rclcpp_VERSION VERSION_GREATER 2.4.2)
+if (rclcpp_VERSION VERSION_GREATER_EQUAL 2.5)
     compile_test(${PROJECT_NAME}_test_domain SOURCE integration/ros2__test_domain.cpp)
 else()
     compile_test(${PROJECT_NAME}_test_domain SOURCE integration/ros2__test_domain__foxy.cpp)

--- a/ros2/static/CMakeLists.txt
+++ b/ros2/static/CMakeLists.txt
@@ -54,7 +54,7 @@ add_library(${PROJECT_NAME}
     SHARED
         src/Factory.cpp
         src/MetaPublisher.cpp
-        $<IF:$<VERSION_GREATER:${rclcpp_VERSION},2.4.2>,src/SystemHandle.cpp,src/SystemHandle__foxy.cpp>
+        $<IF:$<VERSION_GREATER_EQUAL:${rclcpp_VERSION},2.5>,src/SystemHandle.cpp,src/SystemHandle__foxy.cpp>
     )
 
 if (Sanitizers_FOUND)

--- a/ros2/static/test/CMakeLists.txt
+++ b/ros2/static/test/CMakeLists.txt
@@ -83,7 +83,7 @@ compile_test(${PROJECT_NAME}_geometry_msgs SOURCE integration/ros2__geometry_msg
 compile_test(${PROJECT_NAME}_primitive_msgs SOURCE integration/ros2__primitives_msgs.cpp)
 compile_test(${PROJECT_NAME}_test_qos SOURCE integration/ros2__test_qos.cpp)
 
-if (rclcpp_VERSION VERSION_GREATER 2.4.2)
+if (rclcpp_VERSION VERSION_GREATER_EQUAL 2.5)
     compile_test(${PROJECT_NAME}_test_domain SOURCE integration/ros2__test_domain.cpp)
 else()
     compile_test(${PROJECT_NAME}_test_domain SOURCE integration/ros2__test_domain__foxy.cpp)


### PR DESCRIPTION
ROS2-SH relies on rclcpp which broke API from foxy to galactic distros.

In order to check which sources to introduce cmake builtin package version ancillary was used.

On June 29th the promote the rclcpp version on foxy from 2.4.2 to 2.4.3 breaking the version checking.

Updating the cmake checking to rely on minor instead of patch